### PR TITLE
Add vision inference script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # gemma3_finetune
+
+This repository provides an example script for fine-tuning a vision model with QLoRA using the Hugging Face ecosystem. The implementation loosely follows the sample shown in the Gemma documentation.
+
+## Requirements
+
+- `transformers`
+- `datasets`
+- `peft`
+- `bitsandbytes`
+
+Install the dependencies with pip:
+
+```bash
+pip install transformers datasets peft bitsandbytes
+```
+
+## Usage
+
+Run the training script specifying the model and dataset you want to use:
+
+```bash
+python scripts/finetune_vision_qlora.py --model google/vit-base-patch16-224 --dataset beans --epochs 3 --batch 4 --output finetuned_model
+```
+
+The script loads the dataset from the Hugging Face hub, applies a 4-bit quantization setup, and fine-tunes the model with LoRA adapters.
+
+## Inference
+
+After training completes, you can run inference on an image using:
+
+```bash
+python scripts/predict_vision_qlora.py --model finetuned_model --image path/to/image.jpg
+```
+
+The script loads the fine-tuned model with 4-bit weights and prints the predicted label for the input image.

--- a/scripts/finetune_vision_qlora.py
+++ b/scripts/finetune_vision_qlora.py
@@ -1,0 +1,88 @@
+import argparse
+from datasets import load_dataset
+from transformers import (
+    AutoModelForImageClassification,
+    AutoImageProcessor,
+    BitsAndBytesConfig,
+    TrainingArguments,
+    Trainer,
+)
+from peft import LoraConfig, get_peft_model, TaskType
+import torch
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Fine-tune a vision model with QLoRA")
+    parser.add_argument("--model", default="google/vit-base-patch16-224", help="Model ID to fine-tune")
+    parser.add_argument("--dataset", default="beans", help="Dataset name from the HF hub")
+    parser.add_argument("--output", default="finetuned_model", help="Output directory")
+    parser.add_argument("--epochs", type=int, default=3, help="Number of training epochs")
+    parser.add_argument("--batch", type=int, default=4, help="Train batch size")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_compute_dtype=torch.float16,
+    )
+
+    model = AutoModelForImageClassification.from_pretrained(
+        args.model,
+        quantization_config=bnb_config,
+        device_map="auto",
+    )
+    processor = AutoImageProcessor.from_pretrained(args.model)
+
+    lora_config = LoraConfig(
+        r=8,
+        lora_alpha=16,
+        lora_dropout=0.1,
+        bias="none",
+        task_type=TaskType.IMAGE_CLASSIFICATION,
+    )
+
+    model = get_peft_model(model, lora_config)
+    model.print_trainable_parameters()
+
+    dataset = load_dataset(args.dataset)
+
+    def preprocess(batch):
+        images = [img.convert("RGB") for img in batch["image"]]
+        inputs = processor(images=images, return_tensors="pt")
+        inputs["labels"] = batch["labels"]
+        return inputs
+
+    train_ds = dataset["train"].map(preprocess, batched=True)
+    val_ds = dataset.get("validation")
+    if val_ds:
+        val_ds = val_ds.map(preprocess, batched=True)
+
+    training_args = TrainingArguments(
+        output_dir=args.output,
+        per_device_train_batch_size=args.batch,
+        per_device_eval_batch_size=args.batch,
+        num_train_epochs=args.epochs,
+        learning_rate=1e-4,
+        fp16=True,
+        evaluation_strategy="steps" if val_ds else "no",
+        logging_steps=10,
+        save_steps=100,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_ds,
+        eval_dataset=val_ds,
+    )
+    trainer.train()
+    trainer.save_model(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/predict_vision_qlora.py
+++ b/scripts/predict_vision_qlora.py
@@ -1,0 +1,46 @@
+import argparse
+from PIL import Image
+from transformers import (
+    AutoModelForImageClassification,
+    AutoImageProcessor,
+    BitsAndBytesConfig,
+)
+import torch
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run inference with a QLoRA fine-tuned vision model")
+    parser.add_argument("--model", required=True, help="Path to the fine-tuned model")
+    parser.add_argument("--image", required=True, help="Path to an image file")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_use_double_quant=True,
+        bnb_4bit_compute_dtype=torch.float16,
+    )
+
+    model = AutoModelForImageClassification.from_pretrained(
+        args.model,
+        quantization_config=bnb_config,
+        device_map="auto",
+    )
+    processor = AutoImageProcessor.from_pretrained(args.model)
+
+    image = Image.open(args.image).convert("RGB")
+    inputs = processor(images=image, return_tensors="pt").to(model.device)
+
+    with torch.no_grad():
+        logits = model(**inputs).logits
+    pred = logits.argmax(dim=-1).item()
+    label = model.config.id2label.get(pred, str(pred))
+    print(label)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `predict_vision_qlora.py` to run inference on images
- document inference usage in README

## Testing
- `python -m py_compile scripts/finetune_vision_qlora.py scripts/predict_vision_qlora.py`


------
https://chatgpt.com/codex/tasks/task_b_684bd7439560832092ee544903264d52